### PR TITLE
fix web api v2 doc

### DIFF
--- a/webapi/Zucks-Ad-Network-Multi-Native-api-specification-v2.md
+++ b/webapi/Zucks-Ad-Network-Multi-Native-api-specification-v2.md
@@ -71,7 +71,7 @@ JSON文字列を返却します。文字コードはUTF-8となります。
     * `native`
   * `imp_url` : String
     * インプレッション計測用エンドポイント
-  * `image_src` : String
+  * `img_src` : String
     * 広告画像URL
     * 縦横比を保って表示してください
   * `width` : String
@@ -133,7 +133,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
         {
             "type": "native",
             "imp_url": "https:\u002F\u002Fk.zucks.net\u002F...",
-            "image_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
+            "img_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
             "width": "114",
             "height": "114",
             "title": "【広告タイトル1】",
@@ -146,7 +146,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
         {
             "type": "native",
             "imp_url": "https:\u002F\u002Fk.zucks.net\u002F...",
-            "image_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
+            "img_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
             "width": "114",
             "height": "114",
             "title": "【広告タイトル2】",
@@ -172,9 +172,9 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
 
 ## Rendering the Ads
 
-`image_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。  
+`img_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。  
 このURLから画像を取得し、縦横比を保った状態で表示してください。  
-`image_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
+`img_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
 
 `link_button_text` はリンクボタン設置時に利用することができるテキストです。  
 広告によっては空文字の場合があります。
@@ -185,7 +185,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
 
 ### Rendering Sample
 
-1. 広告画像（`image_src`）
+1. 広告画像（`img_src`）
 2. タイトル（`title`）
 3. 広告の本文（`body_text`）
 4. サービス・商品名（`product_name`）

--- a/webapi/Zucks-Ad-Network-Multi-Native-api-specification-v2.md
+++ b/webapi/Zucks-Ad-Network-Multi-Native-api-specification-v2.md
@@ -71,7 +71,7 @@ JSON文字列を返却します。文字コードはUTF-8となります。
     * `native`
   * `imp_url` : String
     * インプレッション計測用エンドポイント
-  * `img_src` : String
+  * `image_src` : String
     * 広告画像URL
     * 縦横比を保って表示してください
   * `width` : String
@@ -133,7 +133,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
         {
             "type": "native",
             "imp_url": "https:\u002F\u002Fk.zucks.net\u002F...",
-            "img_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
+            "image_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
             "width": "114",
             "height": "114",
             "title": "【広告タイトル1】",
@@ -146,7 +146,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
         {
             "type": "native",
             "imp_url": "https:\u002F\u002Fk.zucks.net\u002F...",
-            "img_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
+            "image_src": "https:\u002F\u002Fstatic.zucks.net.zimg.jp\u002Fimage\u002F...",
             "width": "114",
             "height": "114",
             "title": "【広告タイトル2】",
@@ -172,9 +172,9 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
 
 ## Rendering the Ads
 
-`img_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。  
+`image_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。  
 このURLから画像を取得し、縦横比を保った状態で表示してください。  
-`img_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
+`image_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
 
 `link_button_text` はリンクボタン設置時に利用することができるテキストです。  
 広告によっては空文字の場合があります。
@@ -185,7 +185,7 @@ https://sh.zucks.net/opt/native/api/v2m?frameid=_xxxxxxxxxx&num=2&ida=xxxx-xxxx-
 
 ### Rendering Sample
 
-1. 広告画像（`img_src`）
+1. 広告画像（`image_src`）
 2. タイトル（`title`）
 3. 広告の本文（`body_text`）
 4. サービス・商品名（`product_name`）

--- a/webapi/Zucks-Ad-Network-Web-api-specification-2.0.md
+++ b/webapi/Zucks-Ad-Network-Web-api-specification-2.0.md
@@ -66,7 +66,7 @@ Zucks Ad Serverから、JSON文字列を返します。
 
 画像バナー広告のときに返されます:
 
-* image_src: URL. Banner image src.
+* img_src: URL. Banner image src.
   * 画像サイズは、予め入稿いただいた枠サイズに合わせたものが配信されます
 * landing_url: URL.
   * 広告タップ時の遷移先URL
@@ -103,7 +103,7 @@ Img ad:
 {
     "status": "ok",
     "type": "img",
-    "image_src": "http://static.zucks.net.zimg.jp/image/2014/10/28/135005_\u738b\u5bae_320\u00d750(L)_072.jpg.jpeg",
+    "img_src": "http://static.zucks.net.zimg.jp/image/2014/10/28/135005_\u738b\u5bae_320\u00d750(L)_072.jpg.jpeg",
     "imp_url": "http://k.zucks.net/...",
     "landing_url": "http://k.zucks.net/..."
 }
@@ -128,8 +128,8 @@ HTML ad:
 
 ### Img ad
 
-`image_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。そのURLから画像を取得し、内容を表示してください。
-`image_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
+`img_src` は、png/jpg/gif(アニメーション含む)などの画像ファイルを示すURLです。そのURLから画像を取得し、内容を表示してください。
+`img_src` の画像ファイルの内容は不変です。必要に応じてキャッシュして利用することができます。
 
 ### HTML ad
 


### PR DESCRIPTION
画像リンクのkey名が実際のレスポンスと仕様書の内容に誤りがあったので修正
実際のレスポンスではkey名は `img_src`